### PR TITLE
fix text render overflow error

### DIFF
--- a/ominous_beeping_app/lib/main.dart
+++ b/ominous_beeping_app/lib/main.dart
@@ -58,15 +58,20 @@ class OminousState extends State<OminousPage> {
               width: 304,                   
               child: FlashingCircle(),            
             ),
-            Text( "OMINOUS\nBEEPING\nAPP",
-                 textAlign: TextAlign.left,
-                 style: TextStyle(fontFamily: 'Helvetica',
-                                  fontWeight: FontWeight.w600,
-                                  fontSize: 60,
-                                  //color: Colors.white,
-                                  foreground: Paint()..shader = linearGradient,  
-                                  ),
+            Expanded(
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text( "OMINOUS\nBEEPING\nAPP",
+                     textAlign: TextAlign.left,
+                     style: TextStyle(fontFamily: 'Helvetica',
+                                      fontWeight: FontWeight.w600,
+                                      fontSize: 60,
+                                      //color: Colors.white,
+                                      foreground: Paint()..shader = linearGradient,
+                                      ),
 
+                ),
+              ),
             ),
           ],
          )

--- a/ominous_beeping_app/lib/main.dart
+++ b/ominous_beeping_app/lib/main.dart
@@ -52,26 +52,26 @@ class OminousState extends State<OminousPage> {
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
-          children: [  
-            Container(
-              height: 440,
-              width: 304,                   
-              child: FlashingCircle(),            
-            ),
+          children: [
             Expanded(
               child: FittedBox(
                 fit: BoxFit.scaleDown,
-                child: Text( "OMINOUS\nBEEPING\nAPP",
-                     textAlign: TextAlign.left,
-                     style: TextStyle(fontFamily: 'Helvetica',
-                                      fontWeight: FontWeight.w600,
-                                      fontSize: 60,
-                                      //color: Colors.white,
-                                      foreground: Paint()..shader = linearGradient,
-                                      ),
-
+                child: Container(
+                  height: 440,
+                  width: 304,
+                  child: FlashingCircle(),
                 ),
               ),
+            ),
+            Text( "OMINOUS\nBEEPING\nAPP",
+                 textAlign: TextAlign.left,
+                 style: TextStyle(fontFamily: 'Helvetica',
+                                  fontWeight: FontWeight.w600,
+                                  fontSize: 60,
+                                  //color: Colors.white,
+                                  foreground: Paint()..shader = linearGradient,
+                                  ),
+
             ),
           ],
          )


### PR DESCRIPTION
The app didn't render correctly on my device. I suppose that the app was supposed to make the text fit inside the screen, so I made it do that

![flutter_02](https://user-images.githubusercontent.com/19921502/61754763-5f169e80-ad69-11e9-9e88-02621007114e.png)
![flutter_03](https://user-images.githubusercontent.com/19921502/61754764-5f169e80-ad69-11e9-9465-ad9aa6f71f5d.png)
![flutter_04](https://user-images.githubusercontent.com/19921502/61754771-6473e900-ad69-11e9-8327-f6e2d5ca09a4.png)
![flutter_05](https://user-images.githubusercontent.com/19921502/61754772-6473e900-ad69-11e9-95f8-3ab2d1e6f9e6.png)
[overflowerror.txt](https://github.com/LarsDu/OminousBeepingApp/files/3424450/overflowerror.txt)
